### PR TITLE
Fix for issue #12

### DIFF
--- a/dev/clip.js
+++ b/dev/clip.js
@@ -1322,7 +1322,7 @@ function codePen() {
 
   var JSONstring = JSON.stringify(data).replace(/"/g, "&quot;").replace(/'/g, "&apos;");
 
-  var $form = $('<form action="http://codepen.io/pen/define" method="POST" target="_blank">'
+  var $form = $('<form action="https://codepen.io/pen/define" method="POST" target="_blank">'
            + '<input type="hidden" name="data" value=\'' + JSONstring + '\'>'
            + '</form>');
 


### PR DESCRIPTION
This changes the codepen post to send the request via HTTPS which in return, fixes the Edit in CodePen button and stops the warnings in console on Chrome and probably Firefox too knowing their security standards are usually inline with Chrome's