### PR TITLE
remove broken link

### DIFF
--- a/index.html
+++ b/index.html
@@ -177,7 +177,6 @@
 						<a href="https://twitter.com/bennettfeely" class="twitter-follow-button" data-show-count="true">Follow @bennettfeely</a>
 					</div>
 					<p>Find this project on <a href="https://github.com/bennettfeely/Clippy">Github</a>.</p>
-					<p>Want a list of the name of every polygon? Check out my new site, <a href="https://copypastelist.com/math/list-of-polygons/">Copy Paste List</a>.</p>
 				</div>
 			</section>
 		</div>


### PR DESCRIPTION
copypaste list is 404'ing.
https://web.archive.org/web/20210514062650/https://copypastelist.com/ doesn't have a copy either. So  made a PR to removed the sentence with the link